### PR TITLE
[Feat](promise-modal): Add optional group property

### DIFF
--- a/packages/lerx/promise-modal/src/core/handle/alert.ts
+++ b/packages/lerx/promise-modal/src/core/handle/alert.ts
@@ -11,6 +11,7 @@ import type {
 } from '@/promise-modal/types';
 
 interface AlertProps<B> {
+  group?: string;
   subtype?: 'info' | 'success' | 'warning' | 'error';
   title?: ReactNode;
   subtitle?: ReactNode;
@@ -28,6 +29,7 @@ interface AlertProps<B> {
 }
 
 export const alert = <B = any>({
+  group,
   subtype,
   title,
   subtitle,

--- a/packages/lerx/promise-modal/src/core/handle/alert.ts
+++ b/packages/lerx/promise-modal/src/core/handle/alert.ts
@@ -46,6 +46,7 @@ export const alert = <B = any>({
     try {
       ModalManager.open({
         type: 'alert',
+        group,
         subtype,
         resolve: () => resolve(),
         title,

--- a/packages/lerx/promise-modal/src/core/handle/confirm.ts
+++ b/packages/lerx/promise-modal/src/core/handle/confirm.ts
@@ -11,6 +11,7 @@ import type {
 } from '@/promise-modal/types';
 
 interface ConfirmProps<B> {
+  group?: string;
   subtype?: 'info' | 'success' | 'warning' | 'error';
   title?: ReactNode;
   subtitle?: ReactNode;
@@ -25,6 +26,7 @@ interface ConfirmProps<B> {
 }
 
 export const confirm = <B = any>({
+  group,
   subtype,
   title,
   subtitle,

--- a/packages/lerx/promise-modal/src/core/handle/confirm.ts
+++ b/packages/lerx/promise-modal/src/core/handle/confirm.ts
@@ -43,6 +43,7 @@ export const confirm = <B = any>({
     try {
       ModalManager.open({
         type: 'confirm',
+        group,
         subtype,
         resolve: (result) => resolve(result ?? false),
         title,

--- a/packages/lerx/promise-modal/src/core/handle/prompt.ts
+++ b/packages/lerx/promise-modal/src/core/handle/prompt.ts
@@ -12,11 +12,12 @@ import type {
 } from '@/promise-modal/types';
 
 interface PromptProps<T, B = any> {
+  group?: string;
   title?: ReactNode;
   subtitle?: ReactNode;
   content?: ReactNode | ComponentType<PromptContentProps>;
-  Input: (props: PromptInputProps<T>) => ReactNode;
   defaultValue?: T;
+  Input: (props: PromptInputProps<T>) => ReactNode;
   disabled?: (value: T) => boolean;
   returnOnCancel?: boolean;
   background?: ModalBackground<B>;
@@ -29,10 +30,11 @@ interface PromptProps<T, B = any> {
 }
 
 export const prompt = <T, B = any>({
-  defaultValue,
+  group,
   title,
   subtitle,
   content,
+  defaultValue,
   Input,
   disabled,
   returnOnCancel,

--- a/packages/lerx/promise-modal/src/core/handle/prompt.ts
+++ b/packages/lerx/promise-modal/src/core/handle/prompt.ts
@@ -50,6 +50,7 @@ export const prompt = <T, B = any>({
     try {
       ModalManager.open({
         type: 'prompt',
+        group,
         resolve: (result) => resolve(result as T),
         title,
         subtitle,

--- a/packages/lerx/promise-modal/src/core/node/ModalNode/AbstractNode.ts
+++ b/packages/lerx/promise-modal/src/core/node/ModalNode/AbstractNode.ts
@@ -14,6 +14,7 @@ type AbstractNodeProps<T, B> = BaseModal<T, B> & ManagedEntity;
 
 export abstract class AbstractNode<T, B> {
   readonly id: number;
+  readonly group?: string;
   readonly initiator: string;
 
   readonly title?: ReactNode;
@@ -42,6 +43,7 @@ export abstract class AbstractNode<T, B> {
   constructor({
     id,
     initiator,
+    group,
     title,
     subtitle,
     background,
@@ -53,6 +55,7 @@ export abstract class AbstractNode<T, B> {
     BackgroundComponent,
   }: AbstractNodeProps<T, B>) {
     this.id = id;
+    this.group = group;
     this.initiator = initiator;
     this.title = title;
     this.subtitle = subtitle;

--- a/packages/lerx/promise-modal/src/core/node/ModalNode/AlertNode.ts
+++ b/packages/lerx/promise-modal/src/core/node/ModalNode/AlertNode.ts
@@ -23,6 +23,7 @@ export class AlertNode<B> extends AbstractNode<null, B> {
 
   constructor({
     id,
+    group,
     initiator,
     type,
     subtype,
@@ -40,6 +41,7 @@ export class AlertNode<B> extends AbstractNode<null, B> {
   }: AlertNodeProps<B>) {
     super({
       id,
+      group,
       initiator,
       title,
       subtitle,

--- a/packages/lerx/promise-modal/src/core/node/ModalNode/ConfirmNode.ts
+++ b/packages/lerx/promise-modal/src/core/node/ModalNode/ConfirmNode.ts
@@ -20,6 +20,7 @@ export class ConfirmNode<B> extends AbstractNode<boolean, B> {
 
   constructor({
     id,
+    group,
     initiator,
     type,
     subtype,
@@ -37,6 +38,7 @@ export class ConfirmNode<B> extends AbstractNode<boolean, B> {
   }: ConfirmNodeProps<B>) {
     super({
       id,
+      group,
       initiator,
       title,
       subtitle,

--- a/packages/lerx/promise-modal/src/core/node/ModalNode/PromptNode.ts
+++ b/packages/lerx/promise-modal/src/core/node/ModalNode/PromptNode.ts
@@ -26,6 +26,7 @@ export class PromptNode<T, B> extends AbstractNode<T, B> {
 
   constructor({
     id,
+    group,
     initiator,
     type,
     title,
@@ -46,6 +47,7 @@ export class PromptNode<T, B> extends AbstractNode<T, B> {
   }: PromptNodeProps<T, B>) {
     super({
       id,
+      group,
       initiator,
       title,
       subtitle,

--- a/packages/lerx/promise-modal/src/hooks/useActiveModalCount.ts
+++ b/packages/lerx/promise-modal/src/hooks/useActiveModalCount.ts
@@ -8,13 +8,14 @@ import { useModalManagerContext } from '@/promise-modal/providers/ModalManagerCo
 const defaultValidate = (modal?: ModalNode) => modal?.visible;
 
 export const useActiveModalCount = (
-  validate: Fn<[ModalNode?], boolean | undefined> = defaultValidate,
+  validate: Fn<[node?: ModalNode], boolean | undefined> = defaultValidate,
   refreshKey: string | number = 0,
 ) => {
   const { modalIds, getModalNode } = useModalManagerContext();
   return useMemo(() => {
     let count = 0;
-    for (const id of modalIds) {
+    for (let index = 0; index < modalIds.length; index++) {
+      const id = modalIds[index];
       if (validate(getModalNode(id))) count++;
     }
     return count;

--- a/packages/lerx/promise-modal/src/types/base.ts
+++ b/packages/lerx/promise-modal/src/types/base.ts
@@ -6,6 +6,7 @@ import type { ModalBackground } from './background';
 import type { ModalFrameProps } from './modal';
 
 export interface BaseModal<T, B> {
+  group?: string;
   title?: ReactNode;
   subtitle?: ReactNode;
   background?: ModalBackground<B>;


### PR DESCRIPTION
## 개요

이 PR은 promise-modal 패키지에 모달 그룹화 기능을 추가하고 모달 카운트 계산을 최적화합니다.

## 주요 변경사항

### ✨ 새로운 기능

- **모달 그룹화**: `group` 속성을 통한 모달 그룹 관리 기능 추가
  - `AbstractNode`에 `group` 프로퍼티 추가
  - `alert`, `confirm`, `prompt` 함수에 `group` 옵션 추가
  - `BaseModal` 타입에 `group` 속성 추가

### ⚡ 성능 개선

- **모달 카운트 계산 최적화**: `useActiveModalCount` 훅의 성능 개선

## 변경된 파일

- `src/core/handle/alert.ts` - alert 함수에 group 옵션 추가
- `src/core/handle/confirm.ts` - confirm 함수에 group 옵션 추가  
- `src/core/handle/prompt.ts` - prompt 함수에 group 옵션 추가
- `src/core/node/ModalNode/AbstractNode.ts` - AbstractNode에 group 프로퍼티 추가
- `src/core/node/ModalNode/AlertNode.ts` - AlertNode에 group 지원 추가
- `src/core/node/ModalNode/ConfirmNode.ts` - ConfirmNode에 group 지원 추가
- `src/core/node/ModalNode/PromptNode.ts` - PromptNode에 group 지원 추가
- `src/hooks/useActiveModalCount.ts` - 모달 카운트 계산 로직 최적화
- `src/types/base.ts` - BaseModal 타입에 group 속성 추가

## 사용 예시

```typescript
// 그룹화된 모달 사용
const result = await alert({
  title: '알림',
  content: '메시지 내용',
  group: 'notification' // 그룹 지정
});
```

## 테스트

- [ ] 기존 기능 정상 동작 확인
- [ ] 새로운 group 기능 동작 확인
- [ ] 성능 개선 확인

## 관련 이슈

- Resolves #232

---

### 통계
- 9개 파일 변경
- 24줄 추가, 4줄 삭제