### PR TITLE
[Refactor/Test](schema-form): ArrayNode API improvements

### DIFF
--- a/packages/canard/schema-form/coverage/12.RenderTest.stories.tsx
+++ b/packages/canard/schema-form/coverage/12.RenderTest.stories.tsx
@@ -152,7 +152,7 @@ export const InsertInputForm = () => {
                     onChange((prev: number) => (prev || 0) + 1);
                   }}
                 >
-                  custom input {value}
+                  custom input {JSON.stringify(value)}
                 </button>
                 {RenderCount}
               </div>

--- a/packages/canard/schema-form/src/core/__tests__/ArrayNode.test.ts
+++ b/packages/canard/schema-form/src/core/__tests__/ArrayNode.test.ts
@@ -576,4 +576,56 @@ describe('ArrayNode', () => {
     expect(firstItemNameNode?.value).toBe('홍길동');
     expect(firstItemAgeNode?.value).toBe(30);
   });
+
+  it('잘못된 인덱스로 remove 호출 시 값을 변경하지 않고 undefined를 반환해야 함', async () => {
+    const node = nodeFromJsonSchema({
+      jsonSchema: {
+        type: 'object',
+        properties: {
+          tags: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+      },
+    });
+
+    const arrayNode = node?.find('tags') as ArrayNode;
+    arrayNode.setValue(['태그1', '태그2']);
+    await delay();
+
+    const invalidIndices = [-1, 2, 100];
+    for (const idx of invalidIndices) {
+      const removed = await arrayNode.remove(idx);
+      await delay();
+      expect(removed).toBeUndefined();
+      expect(arrayNode.value).toEqual(['태그1', '태그2']);
+    }
+  });
+
+  it('잘못된 인덱스로 update 호출 시 값을 변경하지 않고 undefined를 반환해야 함', async () => {
+    const node = nodeFromJsonSchema({
+      jsonSchema: {
+        type: 'object',
+        properties: {
+          tags: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+      },
+    });
+
+    const arrayNode = node?.find('tags') as ArrayNode;
+    arrayNode.setValue(['태그1', '태그2']);
+    await delay();
+
+    const invalidIndices = [-1, 2, 100];
+    for (const idx of invalidIndices) {
+      const updated = await arrayNode.update(idx, '변경값');
+      await delay();
+      expect(updated).toBeUndefined();
+      expect(arrayNode.value).toEqual(['태그1', '태그2']);
+    }
+  });
 });

--- a/packages/canard/schema-form/src/core/__tests__/ArrayNodeTerminal.test.ts
+++ b/packages/canard/schema-form/src/core/__tests__/ArrayNodeTerminal.test.ts
@@ -162,4 +162,58 @@ describe('ArrayNode-Terminal', () => {
 
     expect(booleanNode.errors).toEqual([]);
   });
+
+  it('터미널 배열에서 잘못된 인덱스로 remove 호출 시 값을 변경하지 않고 undefined를 반환해야 함', async () => {
+    const node = nodeFromJsonSchema({
+      jsonSchema: {
+        type: 'object',
+        properties: {
+          arr: {
+            type: 'array',
+            terminal: true,
+            items: { type: 'boolean' },
+          },
+        },
+      },
+    });
+
+    const booleanNode = node?.find('arr') as ArrayNode;
+    booleanNode.setValue([true, false]);
+    await delay();
+
+    const invalidIndices = [-1, 2, 100];
+    for (const idx of invalidIndices) {
+      const removed = await booleanNode.remove(idx);
+      await delay();
+      expect(removed).toBeUndefined();
+      expect(booleanNode.value).toEqual([true, false]);
+    }
+  });
+
+  it('터미널 배열에서 잘못된 인덱스로 update 호출 시 값을 변경하지 않고 undefined를 반환해야 함', async () => {
+    const node = nodeFromJsonSchema({
+      jsonSchema: {
+        type: 'object',
+        properties: {
+          arr: {
+            type: 'array',
+            terminal: true,
+            items: { type: 'boolean' },
+          },
+        },
+      },
+    });
+
+    const booleanNode = node?.find('arr') as ArrayNode;
+    booleanNode.setValue([true, false]);
+    await delay();
+
+    const invalidIndices = [-1, 2, 100];
+    for (const idx of invalidIndices) {
+      const updated = await booleanNode.update(idx, true);
+      await delay();
+      expect(updated).toBeUndefined();
+      expect(booleanNode.value).toEqual([true, false]);
+    }
+  });
 });

--- a/packages/canard/schema-form/src/core/nodes/AbstractNode/AbstractNode.ts
+++ b/packages/canard/schema-form/src/core/nodes/AbstractNode/AbstractNode.ts
@@ -276,8 +276,8 @@ export abstract class AbstractNode<
     this.propertyKey = this.#name;
     this.escapedKey = escapeSegment(this.propertyKey);
 
-    this.#key = joinSegment(this.parentNode?.path, key ?? this.escapedKey);
     this.#path = joinSegment(this.parentNode?.path, this.escapedKey);
+    this.#key = key ? joinSegment(this.parentNode?.path, key) : this.#path;
 
     this.depth = this.#path
       .split(JSONPointer.Separator)

--- a/packages/canard/schema-form/src/core/nodes/ArrayNode/ArrayNode.ts
+++ b/packages/canard/schema-form/src/core/nodes/ArrayNode/ArrayNode.ts
@@ -12,7 +12,6 @@ import type {
 import {
   type ArrayNodeStrategy,
   BranchStrategy,
-  type IndexId,
   TerminalStrategy,
 } from './strategies';
 import { omitEmptyArray } from './utils';
@@ -143,25 +142,21 @@ export class ArrayNode extends AbstractNode<ArraySchema, ArrayValue> {
 
   /**
    * Updates the value of a specific element.
-   * @param id - ID or index of the element to update
+   * @param index - Index of the element to update
    * @param data - New value
    * @returns {Promise<ArrayValue[number]|undefined>} the value of the updated value
    */
-  public update(
-    this: ArrayNode,
-    id: IndexId | number,
-    data: ArrayValue[number],
-  ) {
-    return this.#strategy.update(id, data);
+  public update(this: ArrayNode, index: number, data: ArrayValue[number]) {
+    return this.#strategy.update(index, data);
   }
 
   /**
    * Removes a specific element.
-   * @param id - ID or index of the element to remove
+   * @param index - Index of the element to remove
    * @returns {Promise<ArrayValue[number]|undefined>} value of the removed value
    */
-  public remove(this: ArrayNode, id: IndexId | number) {
-    return this.#strategy.remove(id);
+  public remove(this: ArrayNode, index: number) {
+    return this.#strategy.remove(index);
   }
 
   /**

--- a/packages/canard/schema-form/src/core/nodes/ArrayNode/filter.ts
+++ b/packages/canard/schema-form/src/core/nodes/ArrayNode/filter.ts
@@ -26,12 +26,12 @@ import type { ArrayNode } from './ArrayNode';
  *         <ArrayItem key={child.key}>
  *           <FormField node={child.node} />
  *           {canRemove && (
- *             <RemoveButton onClick={() => node.removeItem(index)} />
+ *             <RemoveButton onClick={() => node.remove(index)} />
  *           )}
  *         </ArrayItem>
  *       ))}
  *       {canAdd && (
- *         <AddButton onClick={() => node.addItem()}>
+ *         <AddButton onClick={() => node.push()}>
  *           Add Item
  *         </AddButton>
  *       )}

--- a/packages/canard/schema-form/src/core/nodes/ArrayNode/strategies/BranchStrategy/BranchStrategy.ts
+++ b/packages/canard/schema-form/src/core/nodes/ArrayNode/strategies/BranchStrategy/BranchStrategy.ts
@@ -283,7 +283,7 @@ export class BranchStrategy implements ArrayNodeStrategy {
 
   /**
    * Gets information about child nodes.
-   * @returns Array containing ID and node information
+   * @returns Array containing key and node information
    * @private
    */
   private get __edges__() {
@@ -291,7 +291,7 @@ export class BranchStrategy implements ArrayNodeStrategy {
     for (let i = 0, l = this.__keys__.length; i < l; i++) {
       const key = this.__keys__[i];
       edges[i] = {
-        id: key,
+        key: key,
         node: this.__sourceMap__.get(key)!.node,
       };
     }

--- a/packages/canard/schema-form/src/core/nodes/ArrayNode/strategies/BranchStrategy/BranchStrategy.ts
+++ b/packages/canard/schema-form/src/core/nodes/ArrayNode/strategies/BranchStrategy/BranchStrategy.ts
@@ -18,7 +18,7 @@ import type { AllowedValue, ArrayValue } from '@/schema-form/types';
 import type { ArrayNodeStrategy } from '../type';
 import { promiseAfterMicrotask } from './utils';
 
-type IndexId = `[${number}]`;
+type ChildSegmentKey = `${number}#${number}`;
 
 export class BranchStrategy implements ArrayNodeStrategy {
   /** Host ArrayNode instance that this strategy belongs to */
@@ -48,15 +48,15 @@ export class BranchStrategy implements ArrayNodeStrategy {
     if (this.__undefined__) this.__undefined__ = false;
   }
 
-  /** Sequence counter for generating unique IDs for array elements */
-  private __seq__: number = 0;
+  /** Revision counter for generating unique keys for array elements */
+  private __revision__: number = 0;
 
-  /** Array of unique IDs for each element in the array, maintaining order */
-  private __ids__: IndexId[] = [];
+  /** Array of unique keys for each element in the array, maintaining order */
+  private __keys__: ChildSegmentKey[] = [];
 
   /** Map storing actual data and corresponding schema nodes for each array element */
   private __sourceMap__: Map<
-    IndexId,
+    ChildSegmentKey,
     {
       data: any;
       node: SchemaNode;
@@ -104,7 +104,7 @@ export class BranchStrategy implements ArrayNodeStrategy {
    * @returns Length of the array
    */
   public get length() {
-    return this.__ids__.length;
+    return this.__keys__.length;
   }
 
   /**
@@ -112,8 +112,8 @@ export class BranchStrategy implements ArrayNodeStrategy {
    * @internal Internal implementation method. Do not call directly.
    */
   public activate() {
-    for (const id of this.__ids__)
-      (this.__sourceMap__.get(id)?.node as AbstractNode)?.activate(
+    for (const key of this.__keys__)
+      (this.__sourceMap__.get(key)?.node as AbstractNode)?.activate(
         this.__host__,
       );
   }
@@ -168,24 +168,24 @@ export class BranchStrategy implements ArrayNodeStrategy {
     )
       return promiseAfterMicrotask(this.length);
 
-    const id = ('[' + this.__seq__++ + ']') as IndexId;
-    const name = this.__ids__.length.toString();
-    this.__ids__.push(id);
+    const index = '' + this.__keys__.length;
+    const key = (index + '#' + this.__revision__++) as ChildSegmentKey;
+    this.__keys__.push(key);
 
     const defaultValue =
       data !== undefined
         ? data
         : getDefaultValue(this.__host__.jsonSchema.items);
     const childNode = this.__nodeFactory__({
-      key: id,
-      name,
+      key: key,
+      name: index,
       jsonSchema: this.__host__.jsonSchema.items,
       parentNode: this.__host__,
       defaultValue,
-      onChange: this.__handleChangeFactory__(id),
+      onChange: this.__handleChangeFactory__(key),
       nodeFactory: this.__nodeFactory__,
     });
-    this.__sourceMap__.set(id, {
+    this.__sourceMap__.set(key, {
       node: childNode,
       data: childNode.value,
     });
@@ -202,13 +202,12 @@ export class BranchStrategy implements ArrayNodeStrategy {
 
   /**
    * Updates the value of a specific element.
-   * @param id - ID or index of the element to update
+   * @param index - Index of the element to update
    * @param data - New value
    * @returns Returns itself (this) for method chaining
    */
-  public update(id: IndexId | number, data: ArrayValue[number]) {
-    const targetId = typeof id === 'number' ? this.__ids__[id] : id;
-    const node = this.__sourceMap__.get(targetId)?.node;
+  public update(index: number, data: ArrayValue[number]) {
+    const node = this.__sourceMap__.get(this.__keys__[index])?.node;
     if (!node) return promiseAfterMicrotask(undefined);
     node.setValue(data);
     return promiseAfterMicrotask(node.value);
@@ -216,16 +215,16 @@ export class BranchStrategy implements ArrayNodeStrategy {
 
   /**
    * Removes a specific element.
-   * @param id - ID or index of the element to remove
+   * @param index - Index of the element to remove
    * @returns Returns itself (this) for method chaining
    */
-  public remove(id: IndexId | number) {
-    const targetId = typeof id === 'number' ? this.__ids__[id] : id;
+  public remove(index: number) {
+    const targetId = this.__keys__[index];
 
     const removed = this.__sourceMap__.get(targetId);
     if (!removed) return promiseAfterMicrotask(undefined);
 
-    this.__ids__ = this.__ids__.filter((id) => id !== targetId);
+    this.__keys__ = this.__keys__.filter((key) => key !== targetId);
     this.__sourceMap__.delete(targetId);
     this.__updateChildName__();
 
@@ -244,10 +243,10 @@ export class BranchStrategy implements ArrayNodeStrategy {
 
   /** Clears all elements to initialize the array. */
   public clear() {
-    for (let i = 0, l = this.__ids__.length; i < l; i++)
-      this.__sourceMap__.get(this.__ids__[i])?.node.cleanUp(this.__host__);
+    for (let i = 0, l = this.__keys__.length; i < l; i++)
+      this.__sourceMap__.get(this.__keys__[i])?.node.cleanUp(this.__host__);
 
-    this.__ids__ = [];
+    this.__keys__ = [];
     this.__sourceMap__.clear();
 
     this.__changed__ = true;
@@ -288,12 +287,12 @@ export class BranchStrategy implements ArrayNodeStrategy {
    * @private
    */
   private get __edges__() {
-    const edges = new Array<ChildNode>(this.__ids__.length);
-    for (let i = 0, l = this.__ids__.length; i < l; i++) {
-      const id = this.__ids__[i];
+    const edges = new Array<ChildNode>(this.__keys__.length);
+    for (let i = 0, l = this.__keys__.length; i < l; i++) {
+      const key = this.__keys__[i];
       edges[i] = {
-        id,
-        node: this.__sourceMap__.get(id)!.node,
+        id: key,
+        node: this.__sourceMap__.get(key)!.node,
       };
     }
     return edges;
@@ -304,9 +303,9 @@ export class BranchStrategy implements ArrayNodeStrategy {
    * @private
    */
   private __toArray__() {
-    const values = new Array<AllowedValue>(this.__ids__.length);
-    for (let i = 0, l = this.__ids__.length; i < l; i++) {
-      const edge = this.__sourceMap__.get(this.__ids__[i]);
+    const values = new Array<AllowedValue>(this.__keys__.length);
+    for (let i = 0, l = this.__keys__.length; i < l; i++) {
+      const edge = this.__sourceMap__.get(this.__keys__[i]);
       if (edge) values[i] = edge.data;
     }
     return values;
@@ -314,14 +313,14 @@ export class BranchStrategy implements ArrayNodeStrategy {
 
   /**
    * Creates a function to handle value changes for a specific element.
-   * @param id - Element ID
+   * @param key - Child node Key
    * @returns Value change function
    * @private
    */
-  private __handleChangeFactory__(id: IndexId) {
+  private __handleChangeFactory__(key: ChildSegmentKey) {
     return (data: unknown) => {
-      if (!this.__sourceMap__.has(id)) return;
-      this.__sourceMap__.get(id)!.data = data;
+      if (!this.__sourceMap__.has(key)) return;
+      this.__sourceMap__.get(key)!.data = data;
       this.__changed__ = true;
       this.__publishRequestEmitChange__();
     };
@@ -332,10 +331,10 @@ export class BranchStrategy implements ArrayNodeStrategy {
    * @private
    */
   private __updateChildName__() {
-    for (let i = 0, l = this.__ids__.length; i < l; i++) {
-      const id = this.__ids__[i];
-      if (this.__sourceMap__.has(id)) {
-        const node = this.__sourceMap__.get(id)!.node;
+    for (let i = 0, l = this.__keys__.length; i < l; i++) {
+      const key = this.__keys__[i];
+      if (this.__sourceMap__.has(key)) {
+        const node = this.__sourceMap__.get(key)!.node;
         const name = i.toString();
         if (node.name !== name) node.setName(name, this.__host__);
       }

--- a/packages/canard/schema-form/src/core/nodes/ArrayNode/strategies/index.ts
+++ b/packages/canard/schema-form/src/core/nodes/ArrayNode/strategies/index.ts
@@ -1,4 +1,4 @@
 export { BranchStrategy } from './BranchStrategy';
 export { TerminalStrategy } from './TerminalStrategy';
 
-export type { ArrayNodeStrategy, IndexId } from './type';
+export type { ArrayNodeStrategy } from './type';

--- a/packages/canard/schema-form/src/core/nodes/ArrayNode/strategies/type.ts
+++ b/packages/canard/schema-form/src/core/nodes/ArrayNode/strategies/type.ts
@@ -19,7 +19,7 @@ export interface ArrayNodeStrategy {
   get length(): number;
   /**
    * Gets the list of child nodes.
-   * @returns Array containing ID and node information
+   * @returns Array containing key and node information
    */
   get children(): ChildNode[] | null;
   /**

--- a/packages/canard/schema-form/src/core/nodes/ArrayNode/strategies/type.ts
+++ b/packages/canard/schema-form/src/core/nodes/ArrayNode/strategies/type.ts
@@ -39,18 +39,18 @@ export interface ArrayNodeStrategy {
   push(data?: ArrayValue[number]): Promise<number>;
   /**
    * Updates the value of a specific element.
-   * @param id - ID or index of the element to update
+   * @param index - Index of the element to update
    * @param data - New value
    */
   update(
-    id: IndexId | number,
+    index: number,
     data: ArrayValue[number],
   ): Promise<ArrayValue[number] | undefined>;
   /**
    * Removes a specific element.
-   * @param id - ID or index of the element to remove
+   * @param index - Index of the element to remove
    */
-  remove(id: IndexId | number): Promise<ArrayValue[number] | undefined>;
+  remove(index: number): Promise<ArrayValue[number] | undefined>;
   /** Removes the last element from the array. */
   pop(): Promise<ArrayValue[number] | undefined>;
   /** Clears all elements to initialize the array. */
@@ -58,5 +58,3 @@ export interface ArrayNodeStrategy {
   /** Activates pub-sub links for child nodes. */
   activate?(): void;
 }
-
-export type IndexId = `[${number}]`;

--- a/packages/canard/schema-form/src/core/nodes/type.ts
+++ b/packages/canard/schema-form/src/core/nodes/type.ts
@@ -79,7 +79,7 @@ export type SchemaNode =
  * Optional metadata assists with identity and rendering strategies for children.
  */
 export interface ChildNode {
-  id?: string;
+  key?: string;
   salt?: string;
   virtual?: boolean;
   node: SchemaNode;


### PR DESCRIPTION
## TL;DR
ArrayNode의 요소 조작 API를 ID 기반에서 인덱스 기반으로 변경하고, 일관된 네이밍 컨벤션 적용 및 테스트 커버리지 추가

## 📌 주요 변경사항

### 리팩토링

#### 1. ArrayNode API 개선 📌
- **변경 전**: ArrayNode의 요소 조작이 ID 기반으로 동작
- **변경 후**: 인덱스 기반으로 변경하여 더 직관적인 API 제공
- **개선점**: 
  - 배열 조작의 자연스러운 인터페이스 구현
  - 성능 향상 (ID 검색 과정 제거)
  - 코드 간소화

#### 2. 일관된 네이밍 컨벤션 적용
- `id` → `key` 속성명 변경 (ChildNode, BranchStrategy)
- **개선점**: 코드베이스 전체의 일관성 향상

#### 3. AbstractNode 개선
- 조건부 key 설정 로직 추가
- **개선점**: 불필요한 key 할당 방지, 메모리 효율성 개선

### 테스트 추가

#### ArrayNode 및 ArrayNodeTerminal 테스트 📌
- 유효하지 않은 인덱스 처리 테스트 추가
- **개선점**: 
  - 에러 핸들링 검증
  - 코드 안정성 향상
  - 테스트 커버리지 증가 (+106 라인)

## 변경 파일 요약
- **테스트 추가**: 2개 파일 (ArrayNode.test.ts, ArrayNodeTerminal.test.ts)
- **코어 로직 수정**: 8개 파일
- **스토리북 수정**: 1개 파일
- **총 변경**: +173 라인, -88 라인