### PR TITLE
[Enhancement/Refactor](json-schema): JSON Schema reference resolution with base schema merging

### DIFF
--- a/packages/canard/schema-form/coverage/16.RefSchemaUsecase.stories.tsx
+++ b/packages/canard/schema-form/coverage/16.RefSchemaUsecase.stories.tsx
@@ -294,6 +294,7 @@ export const DirectSubSchemaRef = () => {
     title: 'Direct SubSchema Reference',
     type: 'object',
     properties: {
+      type: { type: 'string', enum: ['user', 'admin'], default: 'user' },
       user: {
         type: 'object',
         properties: {
@@ -320,6 +321,19 @@ export const DirectSubSchemaRef = () => {
       },
       userSettings: {
         $ref: '#/properties/user/properties/settings',
+      },
+      oneOf: {
+        type: 'object',
+        oneOf: [
+          {
+            '&if': "../type === 'user'",
+            $ref: '#/properties/user/properties/profile',
+          },
+          {
+            '&if': "../type === 'admin'",
+            $ref: '#/properties/user/properties/settings',
+          },
+        ],
       },
     },
   } satisfies JsonSchema;

--- a/packages/canard/schema-form/src/helpers/jsonSchema/getResolveSchema/utils/getResolveSchemaScanner.ts
+++ b/packages/canard/schema-form/src/helpers/jsonSchema/getResolveSchema/utils/getResolveSchemaScanner.ts
@@ -1,3 +1,5 @@
+import { isEmptyObject } from '@winglet/common-utils/filter';
+import { clone, merge } from '@winglet/common-utils/object';
 import { JsonSchemaScanner } from '@winglet/json-schema/scanner';
 
 import type { JsonSchema } from '@/schema-form/types';
@@ -8,7 +10,13 @@ export const getResolveSchemaScanner = (
 ) =>
   new JsonSchemaScanner({
     options: {
-      resolveReference: (path) => referenceTable.get(path),
+      resolveReference: (path, entry) => {
+        const { $ref: _, ...preferredSchema } = entry.schema;
+        const referenceSchema = referenceTable.get(path);
+        if (referenceSchema === undefined) return;
+        if (isEmptyObject(preferredSchema)) return referenceSchema;
+        return merge(clone(referenceSchema), preferredSchema);
+      },
       maxDepth,
     },
   });

--- a/packages/winglet/json-schema/src/utils/JsonSchemaScanner/__tests__/JsonSchemaScanner.test.ts
+++ b/packages/winglet/json-schema/src/utils/JsonSchemaScanner/__tests__/JsonSchemaScanner.test.ts
@@ -308,6 +308,18 @@ describe('JsonSchemaScanner', () => {
 
       expect(resolveReference).toHaveBeenCalledWith(
         '#/definitions/string',
+        {
+          dataPath: '#/ref',
+          depth: 1,
+          keyword: 'properties',
+          path: '#/properties/ref',
+          referencePath: '#/definitions/string',
+          referenceResolved: true,
+          schema: {
+            type: 'string',
+          },
+          variant: 'ref',
+        },
         undefined,
       );
       expect(visitor.enter).toHaveBeenCalledWith(
@@ -631,6 +643,18 @@ describe('JsonSchemaScannerAsync', () => {
 
       expect(resolveReference).toHaveBeenCalledWith(
         '#/definitions/string',
+        {
+          dataPath: '#/ref',
+          depth: 1,
+          keyword: 'properties',
+          path: '#/properties/ref',
+          referencePath: '#/definitions/string',
+          referenceResolved: true,
+          schema: {
+            type: 'string',
+          },
+          variant: 'ref',
+        },
         undefined,
       );
       // 루트 객체 방문 확인
@@ -697,6 +721,17 @@ describe('JsonSchemaScannerAsync', () => {
 
       expect(resolveReference).toHaveBeenCalledWith(
         '#/definitions/nonexistent',
+        {
+          dataPath: '#/ref',
+          depth: 1,
+          hasReference: true,
+          keyword: 'properties',
+          path: '#/properties/ref',
+          schema: {
+            $ref: '#/definitions/nonexistent',
+          },
+          variant: 'ref',
+        },
         undefined,
       );
       // Should not visit undefined reference

--- a/packages/winglet/json-schema/src/utils/JsonSchemaScanner/async/JsonSchemaScannerAsync.ts
+++ b/packages/winglet/json-schema/src/utils/JsonSchemaScanner/async/JsonSchemaScannerAsync.ts
@@ -347,7 +347,7 @@ export class JsonSchemaScannerAsync<ContextType = void> {
 
             const resolvedReference =
               resolveReference && !isDefinitionSchema(entry.path)
-                ? await resolveReference(referencePath, context)
+                ? await resolveReference(referencePath, entry, context)
                 : undefined;
 
             if (resolvedReference) {

--- a/packages/winglet/json-schema/src/utils/JsonSchemaScanner/sync/JsonSchemaScanner.ts
+++ b/packages/winglet/json-schema/src/utils/JsonSchemaScanner/sync/JsonSchemaScanner.ts
@@ -316,7 +316,7 @@ export class JsonSchemaScanner<ContextType = void> {
             }
             const resolvedReference =
               resolveReference && !isDefinitionSchema(entry.path)
-                ? resolveReference(referencePath, context)
+                ? resolveReference(referencePath, entry, context)
                 : undefined;
 
             if (resolvedReference) {

--- a/packages/winglet/json-schema/src/utils/JsonSchemaScanner/type.ts
+++ b/packages/winglet/json-schema/src/utils/JsonSchemaScanner/type.ts
@@ -78,7 +78,7 @@ export interface JsonScannerOptions<ContextType = void> {
   >;
   /** Function to resolve $ref references */
   resolveReference?: Fn<
-    [reference: string, context?: ContextType],
+    [reference: string, entry: SchemaEntry, context?: ContextType],
     UnknownSchema | undefined
   >;
   /** Maximum traversal depth */
@@ -90,7 +90,7 @@ export interface JsonScannerOptions<ContextType = void> {
 export interface JsonScannerOptionsAsync<ContextType = void>
   extends JsonScannerOptions<ContextType> {
   resolveReference?: Fn<
-    [reference: string, context?: ContextType],
+    [reference: string, entry: SchemaEntry, context?: ContextType],
     UnknownSchema | Promise<UnknownSchema | undefined> | undefined
   >;
 }


### PR DESCRIPTION
## 📋 TL;DR
JSON Schema의 `$ref` 참조 해석 시 base schema와 참조된 schema를 병합하여 더 유연한 스키마 구성을 지원합니다.

## 🔄 변경사항 분석

### ✨ 새로운 기능
- **조건부 스키마 참조**: `oneOf`와 `&if` 조건을 통해 동적으로 다른 스키마를 참조할 수 있는 기능 추가
- **Base Schema 병합**: `$ref`가 있는 스키마에 추가 속성이 있을 경우, 참조된 스키마와 병합하여 반환

### 🚀 개선사항
- **JsonSchemaScanner API 개선**: `resolveReference` 함수가 이제 `SchemaEntry`를 추가 파라미터로 받아 더 많은 컨텍스트 정보 활용 가능
- **getResolveSchemaScanner 로직 강화**: 빈 객체가 아닌 base schema가 있을 경우 참조된 스키마와 자동으로 병합

### 📝 테스트 및 문서
- **Storybook 스토리 추가**: `DirectSubSchemaRef` 스토리에 타입 기반 조건부 참조 예제 추가
- **테스트 커버리지 확장**: JsonSchemaScanner 테스트에서 새로운 API 시그니처 검증 추가

## 🔍 주요 변경 파일
- `packages/canard/schema-form/coverage/16.RefSchemaUsecase.stories.tsx`: 조건부 참조 예제 추가
- `packages/canard/schema-form/src/helpers/jsonSchema/getResolveSchema/utils/getResolveSchemaScanner.ts`: Base schema 병합 로직 구현
- `packages/winglet/json-schema/src/utils/JsonSchemaScanner/type.ts`: API 타입 시그니처 업데이트
- `packages/winglet/json-schema/src/utils/JsonSchemaScanner/*/`: Scanner 구현체 업데이트

## 🧪 테스트 확인사항
- [x] 기존 기능 회귀 테스트
- [x] 새로운 base schema 병합 동작 확인
- [x] TypeScript 컴파일 성공
- [x] 린트 검사 통과

## 📦 영향받는 패키지
- `@canard/schema-form`: JSON Schema 참조 해석 개선
- `@winglet/json-schema`: Scanner API 업데이트

## 💡 사용 예시
```typescript
// 이제 $ref와 함께 추가 속성을 정의하면 자동으로 병합됩니다
const schema = {
  properties: {
    field: {
      $ref: '#/definitions/baseField',
      title: 'Custom Title', // 병합될 추가 속성
      required: true
    }
  }
}
```

---

🤖 이 PR은 자동화된 분석을 통해 생성되었습니다.