### PR TITLE
docs(schema-form): add array output filters example to the documents site

### DIFF
--- a/documents/docs/canard/schema-form/examples/array-output-filters.mdx
+++ b/documents/docs/canard/schema-form/examples/array-output-filters.mdx
@@ -1,0 +1,40 @@
+---
+sidebar_label: 'Array Output Filters'
+sidebar_position: 12
+---
+
+import LazyDemo from '@site/src/components/LazyDemo';
+
+# Array Output Filters (omitTrailing / omitEmpty)
+
+`options.omitTrailing` lets an array offer empty rows up front while keeping them out of the value the form emits. Only **trailing** `undefined` items are dropped — leading and middle holes stay in place, so error `dataPath`s and validation indexes keep pointing at the row the user sees.
+
+:::info Key Features
+
+- `omitTrailing: true` — opt-in; trims trailing `undefined` from the emitted value only
+- `omitEmpty` — on by default; an empty array disappears from its parent value
+- Filter order — `omitTrailing` runs first, `omitEmpty` second
+- Two channels — `node.value` (raw, what renders) vs `node.normalizedValue` (refined, what is emitted)
+  :::
+
+The demo below renders three arrays that share one shape (`minItems: 3`, string items) and differ only in their `options`. Each starts with three empty rows; the table under the form shows both channels side by side, so you can watch the rendered row count and the emitted value diverge.
+
+| Path       | `options`                                  | Emitted at first paint        |
+| ---------- | ------------------------------------------ | ----------------------------- |
+| `/tags`    | `{ omitTrailing: true }`                   | key absent (`[]` → omitEmpty) |
+| `/notes`   | none                                       | `[null, null, null]`          |
+| `/aliases` | `{ omitTrailing: true, omitEmpty: false }` | `[]`                          |
+
+:::caution minItems and validation
+Validation reads the **normalized** value. Pairing `minItems: 3` with `omitTrailing: true` means an array holding one filled row is validated as length 1, not 3. Use `minItems` to decide how many rows to offer only when the emitted contract also wants that many; otherwise leave it off and let users add rows.
+:::
+
+:::tip Custom array inputs
+Count rows from `node.children`, never from `value.length` — the filtered value is shorter than the rendered row count by design.
+:::
+
+<LazyDemo
+  load={() =>
+    import('@site/src/components/demos/examples/ArrayOutputFiltersDemo')
+  }
+/>

--- a/documents/docs/canard/schema-form/examples/index.mdx
+++ b/documents/docs/canard/schema-form/examples/index.mdx
@@ -28,6 +28,7 @@ Try these live demos to see JSON Schema features in action:
 - [Role-Based Access](./role-based-access) — Field visibility vs activity control
 - [Nested Profile & Security](./nested-profile) — Deep nesting with conditional validation
 - [Tuple Arrays](./tuple-arrays) — Fixed-length typed arrays with prefixItems
+- [Array Output Filters](./array-output-filters) — Trailing-empty trimming with omitTrailing / omitEmpty
 - [Virtualized Form](./virtualized-form) — Render-level virtualization for very large forms (300+ fields)
 
 ---

--- a/documents/i18n/ko/docusaurus-plugin-content-docs/current/canard/schema-form/examples/array-output-filters.mdx
+++ b/documents/i18n/ko/docusaurus-plugin-content-docs/current/canard/schema-form/examples/array-output-filters.mdx
@@ -1,0 +1,40 @@
+---
+sidebar_label: '배열 출력 필터'
+sidebar_position: 12
+---
+
+import LazyDemo from '@site/src/components/LazyDemo';
+
+# 배열 출력 필터 (omitTrailing / omitEmpty)
+
+`options.omitTrailing`을 켜면 배열이 빈 input을 먼저 노출하면서도 그 빈 항목을 폼이 내보내는 값에서 제외할 수 있습니다. 제거 대상은 **후행** 연속 `undefined`뿐이며, 선행·중간 `undefined`는 그대로 보존되어 error `dataPath`와 validation index 정합이 유지됩니다.
+
+:::info 주요 기능
+
+- `omitTrailing: true` — opt-in. 내보내는 값에서만 후행 `undefined`를 잘라냅니다
+- `omitEmpty` — 기본 활성. 빈 배열을 부모 값에서 제거합니다
+- 필터 순서 — `omitTrailing`이 먼저, `omitEmpty`가 그 다음입니다
+- 값 2채널 — `node.value`(raw, 렌더되는 값) vs `node.normalizedValue`(정제된 값, 방출되는 값)
+  :::
+
+아래 데모는 형태가 같고(`minItems: 3`, 문자열 항목) `options`만 다른 배열 3개를 렌더링합니다. 셋 다 빈 행 3개로 시작하며, 폼 아래 표가 두 채널을 나란히 보여주므로 렌더된 행 수와 방출되는 값이 어떻게 갈라지는지 확인할 수 있습니다.
+
+| 경로       | `options`                                  | 첫 렌더 시 방출값                   |
+| ---------- | ------------------------------------------ | ----------------------------------- |
+| `/tags`    | `{ omitTrailing: true }`                   | 키 자체가 사라짐 (`[]` → omitEmpty) |
+| `/notes`   | 없음                                       | `[null, null, null]`                |
+| `/aliases` | `{ omitTrailing: true, omitEmpty: false }` | `[]`                                |
+
+:::caution minItems와 유효성 검사
+validation은 **정제된 값**을 읽습니다. `minItems: 3`과 `omitTrailing: true`를 함께 쓰면 한 행만 채워진 배열은 길이 3이 아니라 1로 검증됩니다. 노출할 행 수를 `minItems`로 정하는 것은 방출되는 값의 계약도 그 개수를 요구할 때만 적절합니다. 그렇지 않다면 `minItems`를 빼고 사용자가 행을 추가하도록 두세요.
+:::
+
+:::tip 커스텀 배열 입력
+행 수는 `value.length`가 아니라 `node.children` 기준으로 세야 합니다 — 방출 값이 렌더된 행보다 짧은 것이 설계입니다.
+:::
+
+<LazyDemo
+  load={() =>
+    import('@site/src/components/demos/examples/ArrayOutputFiltersDemo')
+  }
+/>

--- a/documents/i18n/ko/docusaurus-plugin-content-docs/current/canard/schema-form/examples/index.mdx
+++ b/documents/i18n/ko/docusaurus-plugin-content-docs/current/canard/schema-form/examples/index.mdx
@@ -14,10 +14,12 @@ import ForAI from '@site/src/components/ForAI';
 라이브 데모를 통해 JSON Schema 기능을 직접 체험해보세요:
 
 ### 시작하기
+
 - [기본 폼](./basic-form) — 기본 필드 타입: 텍스트, 숫자, 날짜, 열거형, 스위치
 - [자동 계산](./auto-calculation) — computed.derived를 활용한 실시간 수식 계산
 
 ### 고급 패턴
+
 - [조건부 등록](./conditional-registration) — 다단계 if/then/else 조건 분기
 - [동적 빌링](./dynamic-billing) — 3개 필드의 캐스케이딩 조건
 - [고용 계약](./employment-contract) — oneOf와 const 기반 필드셋 전환
@@ -26,6 +28,7 @@ import ForAI from '@site/src/components/ForAI';
 - [역할 기반 접근 제어](./role-based-access) — 필드 가시성(visible)과 활성화(active) 제어
 - [중첩 프로필 & 보안](./nested-profile) — 깊은 중첩 구조와 조건부 유효성 검사
 - [튜플 배열](./tuple-arrays) — prefixItems를 활용한 고정 길이 타입 배열
+- [배열 출력 필터](./array-output-filters) — omitTrailing / omitEmpty를 활용한 꼬리 빈 값 정리
 - [가상화 폼](./virtualized-form) — 초대형 폼(300+ 필드)을 위한 렌더 레벨 가상화
 
 ---
@@ -40,11 +43,11 @@ import { Form, ShowError } from '@canard/schema-form';
 const schema = {
   type: 'object',
   properties: {
-    name:      { type: 'string',  title: 'Name',     minLength: 1, maxLength: 100 },
-    age:       { type: 'number',  title: 'Age',      minimum: 0, maximum: 150 },
-    email:     { type: 'string',  title: 'Email',    format: 'email' },
-    isActive:  { type: 'boolean', title: 'Active' },
-    bio:       { type: 'string',  title: 'Bio',      maxLength: 500 },
+    name: { type: 'string', title: 'Name', minLength: 1, maxLength: 100 },
+    age: { type: 'number', title: 'Age', minimum: 0, maximum: 150 },
+    email: { type: 'string', title: 'Email', format: 'email' },
+    isActive: { type: 'boolean', title: 'Active' },
+    bio: { type: 'string', title: 'Bio', maxLength: 500 },
   },
   required: ['name', 'email'],
 } as const;
@@ -69,15 +72,18 @@ function BasicForm() {
 const schema = {
   type: 'object',
   properties: {
-    name:     { type: 'string' },
-    nickname: { type: ['string', 'null'] as const },  // nullable
-    score:    { type: ['number', 'null'] as const },   // nullable
+    name: { type: 'string' },
+    nickname: { type: ['string', 'null'] as const }, // nullable
+    score: { type: ['number', 'null'] as const }, // nullable
   },
 } as const;
 
 // Custom input that handles null
 const NullableTextInput: FC<FormTypeInputProps<string | null>> = ({
-  value, onChange, nullable, placeholder,
+  value,
+  onChange,
+  nullable,
+  placeholder,
 }) => (
   <input
     value={value ?? ''}
@@ -105,7 +111,7 @@ const schema = {
   then: {
     properties: {
       companyName: { type: 'string', title: 'Company Name', minLength: 1 },
-      taxId:       { type: 'string', title: 'Tax ID' },
+      taxId: { type: 'string', title: 'Tax ID' },
     },
     required: ['companyName'],
   },
@@ -141,9 +147,13 @@ const schema = {
     {
       '&if': "./paymentMethod === 'card'",
       properties: {
-        cardNumber: { type: 'string', title: 'Card Number', pattern: '^[0-9]{16}$' },
-        expiryDate: { type: 'string', title: 'Expiry',      format: 'date' },
-        cvv:        { type: 'string', title: 'CVV',         pattern: '^[0-9]{3,4}$' },
+        cardNumber: {
+          type: 'string',
+          title: 'Card Number',
+          pattern: '^[0-9]{16}$',
+        },
+        expiryDate: { type: 'string', title: 'Expiry', format: 'date' },
+        cvv: { type: 'string', title: 'CVV', pattern: '^[0-9]{3,4}$' },
       },
       required: ['cardNumber', 'expiryDate', 'cvv'],
     },
@@ -151,7 +161,7 @@ const schema = {
       '&if': "./paymentMethod === 'bank'",
       properties: {
         accountNumber: { type: 'string', title: 'Account Number' },
-        routingNumber:  { type: 'string', title: 'Routing Number' },
+        routingNumber: { type: 'string', title: 'Routing Number' },
       },
       required: ['accountNumber', 'routingNumber'],
     },
@@ -172,7 +182,7 @@ const schema = {
 const schema = {
   type: 'object',
   properties: {
-    notifyBySms:   { type: 'boolean', title: 'Notify by SMS' },
+    notifyBySms: { type: 'boolean', title: 'Notify by SMS' },
     notifyByEmail: { type: 'boolean', title: 'Notify by Email' },
   },
   anyOf: [
@@ -186,7 +196,11 @@ const schema = {
     {
       '&if': './notifyByEmail === true',
       properties: {
-        notificationEmail: { type: 'string', title: 'Notification Email', format: 'email' },
+        notificationEmail: {
+          type: 'string',
+          title: 'Notification Email',
+          format: 'email',
+        },
       },
       required: ['notificationEmail'],
     },
@@ -201,15 +215,15 @@ const schema = {
 const basePersonSchema = {
   properties: {
     firstName: { type: 'string', title: 'First Name', minLength: 1 },
-    lastName:  { type: 'string', title: 'Last Name',  minLength: 1 },
+    lastName: { type: 'string', title: 'Last Name', minLength: 1 },
   },
   required: ['firstName', 'lastName'],
 };
 
 const contactInfoSchema = {
   properties: {
-    email:  { type: 'string', title: 'Email',  format: 'email' },
-    phone:  { type: 'string', title: 'Phone' },
+    email: { type: 'string', title: 'Email', format: 'email' },
+    phone: { type: 'string', title: 'Phone' },
   },
   required: ['email'],
 };
@@ -240,8 +254,8 @@ const schema = {
         type: 'object',
         properties: {
           street: { type: 'string', title: 'Street' },
-          city:   { type: 'string', title: 'City'   },
-          zip:    { type: 'string', title: 'ZIP'    },
+          city: { type: 'string', title: 'City' },
+          zip: { type: 'string', title: 'ZIP' },
         },
         required: ['street', 'city'],
       },
@@ -269,18 +283,18 @@ function ArrayManager({ formRef }) {
 const schema = {
   type: 'object',
   properties: {
-    isPremium:    { type: 'boolean', title: 'Premium Member' },
-    discount:     {
+    isPremium: { type: 'boolean', title: 'Premium Member' },
+    discount: {
       type: 'number',
       title: 'Discount %',
       minimum: 0,
       maximum: 100,
       computed: {
-        visible:  '../isPremium === true',
+        visible: '../isPremium === true',
         readOnly: '../isPremium === false',
       },
     },
-    memberSince:  {
+    memberSince: {
       type: 'string',
       title: 'Member Since',
       format: 'date',
@@ -307,6 +321,7 @@ const schema = {
 
 ```tsx
 import type { FC } from 'react';
+
 import type { FormTypeInputProps } from '@canard/schema-form';
 
 // Custom rating input for { type: 'number', formType: 'rating' }
@@ -408,9 +423,13 @@ const schema = {
 
 ```tsx
 import { useRef } from 'react';
+
 import { Form, type FormHandle, useFormSubmit } from '@canard/schema-form';
 
-const schema = { type: 'object', properties: { name: { type: 'string' } } } as const;
+const schema = {
+  type: 'object',
+  properties: { name: { type: 'string' } },
+} as const;
 
 function MyForm() {
   const formRef = useRef<FormHandle<typeof schema>>(null);
@@ -426,11 +445,7 @@ function MyForm() {
 
   return (
     <>
-      <Form
-        ref={formRef}
-        jsonSchema={schema}
-        onSubmit={handleSubmit}
-      />
+      <Form ref={formRef} jsonSchema={schema} onSubmit={handleSubmit} />
       <button onClick={submit} disabled={pending}>
         {pending ? 'Saving…' : 'Save'}
       </button>
@@ -451,7 +466,7 @@ function MyForm() {
   jsonSchema={schema}
   defaultValue={{ name: 'Alice' }}
   onChange={(value) => console.log(value)}
-/>
+/>;
 
 // ── Imperative (for programmatic updates) ──────────────────────
 // Use ref to read/write values imperatively.
@@ -460,10 +475,7 @@ formRef.current?.setValue({ name: 'Bob' });
 
 // ── FormHandle setValue with merge ────────────────────────────
 // Merge only changed fields (deep merge)
-formRef.current?.setValue(
-  { address: { city: 'Seoul' } },
-  SetValueOption.Merge
-);
+formRef.current?.setValue({ address: { city: 'Seoul' } }, SetValueOption.Merge);
 ```
 
 ## Custom Layout with Form.Group
@@ -472,11 +484,11 @@ formRef.current?.setValue(
 const profileSchema = {
   type: 'object',
   properties: {
-    avatar:     { type: 'string', title: 'Avatar',      formType: 'image-upload' },
-    firstName:  { type: 'string', title: 'First Name',  minLength: 1 },
-    lastName:   { type: 'string', title: 'Last Name',   minLength: 1 },
-    bio:        { type: 'string', title: 'Bio',         maxLength: 500 },
-    website:    { type: 'string', title: 'Website',     format: 'uri' },
+    avatar: { type: 'string', title: 'Avatar', formType: 'image-upload' },
+    firstName: { type: 'string', title: 'First Name', minLength: 1 },
+    lastName: { type: 'string', title: 'Last Name', minLength: 1 },
+    bio: { type: 'string', title: 'Bio', maxLength: 500 },
+    website: { type: 'string', title: 'Website', format: 'uri' },
   },
   required: ['firstName', 'lastName'],
 } as const;
@@ -489,9 +501,9 @@ function ProfileForm() {
       </div>
       <div className="name-row">
         <Form.Group path="/firstName" placeholder="First name" />
-        <Form.Group path="/lastName"  placeholder="Last name" />
+        <Form.Group path="/lastName" placeholder="Last name" />
       </div>
-      <Form.Group path="/bio"     placeholder="Tell us about yourself" />
+      <Form.Group path="/bio" placeholder="Tell us about yourself" />
       <Form.Group path="/website" placeholder="https://..." />
     </Form>
   );
@@ -525,10 +537,13 @@ import { isArrayNode, isObjectNode } from '@canard/schema-form';
 
 function FormController({ formRef }) {
   const fillDefaults = () => {
-    formRef.current?.setValue({
-      status: 'draft',
-      createdAt: new Date().toISOString(),
-    }, SetValueOption.Merge);
+    formRef.current?.setValue(
+      {
+        status: 'draft',
+        createdAt: new Date().toISOString(),
+      },
+      SetValueOption.Merge,
+    );
   };
 
   const addTag = () => {
@@ -559,8 +574,8 @@ import type { InferValueType } from '@winglet/json-schema';
 const schema = {
   type: 'object',
   properties: {
-    name:     { type: 'string' },
-    age:      { type: 'number' },
+    name: { type: 'string' },
+    age: { type: 'number' },
     nickname: { type: ['string', 'null'] as const },
   },
   required: ['name'],

--- a/documents/src/components/demos/examples/ArrayOutputFiltersDemo.tsx
+++ b/documents/src/components/demos/examples/ArrayOutputFiltersDemo.tsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import {
+  Form,
+  type FormHandle,
+  type SchemaNode,
+  registerPlugin,
+  useSchemaNodeTracker,
+} from '@canard/schema-form';
+import { plugin } from '@canard/schema-form-antd6-plugin';
+
+import DemoWrapper from '../DemoWrapper';
+
+registerPlugin(plugin);
+
+const schema = {
+  type: 'object',
+  properties: {
+    tags: {
+      type: 'array',
+      title: 'Tags — omitTrailing',
+      description:
+        'Three empty rows are offered up front; only what you filled in is emitted',
+      minItems: 3,
+      items: { type: 'string', placeholder: 'tag' },
+      options: { omitTrailing: true },
+    },
+    notes: {
+      type: 'array',
+      title: 'Notes — no filter',
+      description:
+        'Same shape without the option: every offered row reaches the emitted value',
+      minItems: 3,
+      items: { type: 'string', placeholder: 'note' },
+    },
+    aliases: {
+      type: 'array',
+      title: 'Aliases — omitTrailing + omitEmpty: false',
+      description:
+        'Trailing rows are trimmed, but an all-empty array stays [] instead of disappearing',
+      minItems: 3,
+      items: { type: 'string', placeholder: 'alias' },
+      options: { omitTrailing: true, omitEmpty: false },
+    },
+  },
+};
+
+const TRACKED_PATHS = ['/tags', '/notes', '/aliases'];
+
+const CELL_STYLE = {
+  padding: '4px 8px',
+  borderTop: '1px solid var(--ifm-color-emphasis-300)',
+} as const;
+
+/** `JSON.stringify(undefined)` returns `undefined`, which React renders as nothing. */
+const show = (value: unknown) => JSON.stringify(value) ?? 'undefined';
+
+/**
+ * One row of the two-channel table, tracking a single array node.
+ * @remarks Each array node is tracked on its own: adding an empty row leaves the
+ *          filtered root value untouched, so a root-level tracker would miss it.
+ */
+function ChannelRow({ node }: { node: SchemaNode }) {
+  useSchemaNodeTracker(node);
+  return (
+    <tr>
+      <td style={CELL_STYLE}>
+        <code>{node.path}</code>
+      </td>
+      <td style={{ ...CELL_STYLE, textAlign: 'center' }}>
+        {node.children?.length ?? 0}
+      </td>
+      <td style={CELL_STYLE}>
+        <code>{show(node.value)}</code>
+      </td>
+      <td style={CELL_STYLE}>
+        <code>{show(node.normalizedValue)}</code>
+      </td>
+    </tr>
+  );
+}
+
+export default function ArrayOutputFiltersDemo() {
+  const [values, setValues] = useState<unknown>({});
+  const formRef = useRef<FormHandle>(null);
+  const [nodes, setNodes] = useState<SchemaNode[]>([]);
+
+  useEffect(() => {
+    const handle = formRef.current;
+    if (!handle) return;
+    setNodes(
+      TRACKED_PATHS.map((path) => handle.findNode(path)).filter(
+        (node): node is SchemaNode => node !== null,
+      ),
+    );
+  }, []);
+
+  return (
+    <DemoWrapper schema={schema} values={values}>
+      <Form ref={formRef} jsonSchema={schema as any} onChange={setValues} />
+      <table
+        style={{
+          marginTop: 16,
+          width: '100%',
+          fontSize: 13,
+          fontFamily: 'var(--ifm-font-family-monospace)',
+        }}
+      >
+        <thead>
+          <tr>
+            <th style={{ ...CELL_STYLE, textAlign: 'left' }}>path</th>
+            <th style={CELL_STYLE}>rendered rows</th>
+            <th style={{ ...CELL_STYLE, textAlign: 'left' }}>
+              node.value (raw)
+            </th>
+            <th style={{ ...CELL_STYLE, textAlign: 'left' }}>
+              node.normalizedValue (emitted)
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {nodes.map((node) => (
+            <ChannelRow key={node.path} node={node} />
+          ))}
+        </tbody>
+      </table>
+    </DemoWrapper>
+  );
+}

--- a/packages/canard/schema-form/src/DETAIL.md
+++ b/packages/canard/schema-form/src/DETAIL.md
@@ -14,11 +14,11 @@
 
 `types/jsonSchema.ts`가 선언하는 `options` 필드. 각 옵션은 특정 스키마 타입에만 존재한다.
 
-| 옵션 | 적용 스키마 | 선언 위치 | 계약 |
-| ---- | ----------- | --------- | ---- |
-| `trim?: boolean` | `NonNullableStringSchema` · `NullableStringSchema` | `types/jsonSchema.ts:139`, `:148` | 필드가 `Blurred`를 방출할 때 저장된 값을 공백 트림된 형태로 **교체**한다. 저장 값 자체가 바뀌므로 raw `value`에도 반영된다 |
-| `omitTrailing?: boolean` | `NonNullableArraySchema` · `NullableArraySchema` | `types/jsonSchema.ts:173`, `:182` | 배열의 `normalizedValue`에서 후행 `undefined` 항목을 제거한다. 적용 범위는 부모 전파·루트 검증·외부 방출이며, **자식 노드는 raw 배열을 유지**한다 |
-| `omitEmpty?: boolean` | 객체 스키마 | `types/jsonSchema.ts:266` | 부모로 전파되는 값에서 빈 항목을 제거한다 |
+| 옵션                     | 적용 스키마                                        | 선언 위치                         | 계약                                                                                                                                              |
+| ------------------------ | -------------------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `trim?: boolean`         | `NonNullableStringSchema` · `NullableStringSchema` | `types/jsonSchema.ts:139`, `:148` | 필드가 `Blurred`를 방출할 때 저장된 값을 공백 트림된 형태로 **교체**한다. 저장 값 자체가 바뀌므로 raw `value`에도 반영된다                        |
+| `omitTrailing?: boolean` | `NonNullableArraySchema` · `NullableArraySchema`   | `types/jsonSchema.ts:173`, `:182` | 배열의 `normalizedValue`에서 후행 `undefined` 항목을 제거한다. 적용 범위는 부모 전파·루트 검증·외부 방출이며, **자식 노드는 raw 배열을 유지**한다 |
+| `omitEmpty?: boolean`    | 객체 스키마                                        | `types/jsonSchema.ts:266`         | 부모로 전파되는 값에서 빈 항목을 제거한다                                                                                                         |
 
 `trim`과 `omitTrailing`의 차이가 이 표의 요점이다 — `trim`은 **저장 값을 교체**하는 옵션이고, `omitTrailing`은 **방출 값만 걸러내는** 옵션이다. 후자는 raw 상태를 보존하므로 되돌릴 수 있고, 전자는 그렇지 않다.
 
@@ -26,13 +26,13 @@
 
 ### 값 채널
 
-| 표면 | 채널 |
-| ---- | ---- |
+| 표면                                                      | 채널                     |
+| --------------------------------------------------------- | ------------------------ |
 | `FormHandle.getValue()` · `submit` · 루트 `onChange` 방출 | 정제 (`normalizedValue`) |
-| `FormHandle.setValue()` | raw |
-| `node.value` · `UpdateValue` 이벤트 payload | raw |
-| `node.normalizedValue` | 정제 |
-| `node.enhancedValue` | 정제 + 가상 필드 |
+| `FormHandle.setValue()`                                   | raw                      |
+| `node.value` · `UpdateValue` 이벤트 payload               | raw                      |
+| `node.normalizedValue`                                    | 정제                     |
+| `node.enhancedValue`                                      | 정제 + 가상 필드         |
 
 ## Acceptance Criteria
 

--- a/packages/canard/schema-form/src/components/Form/DETAIL.md
+++ b/packages/canard/schema-form/src/components/Form/DETAIL.md
@@ -13,13 +13,13 @@
 
 ### 값 채널
 
-| 표면 | 읽는 값 | 위치 |
-| ---- | ------- | ---- |
-| `FormHandle.getValue()` | `rootNode.normalizedValue` | `Form.tsx:154` |
-| `submit` / `onSubmit` 인자 | `rootNode.normalizedValue` | `Form.tsx:116`, `:124` |
-| 최초 `onChange` 방출 | `rootNode.normalizedValue` | `Form.tsx:138` |
-| `FormHandle.setValue(value, options)` | raw → `rootNode.setValue` | `Form.tsx:155` |
-| `FormHandle.node` / `findNode` / `findNodes` | 노드 자체 (raw 접근 가능) | `Form.tsx:146`, `:152`, `:153` |
+| 표면                                         | 읽는 값                    | 위치                           |
+| -------------------------------------------- | -------------------------- | ------------------------------ |
+| `FormHandle.getValue()`                      | `rootNode.normalizedValue` | `Form.tsx:154`                 |
+| `submit` / `onSubmit` 인자                   | `rootNode.normalizedValue` | `Form.tsx:116`, `:124`         |
+| 최초 `onChange` 방출                         | `rootNode.normalizedValue` | `Form.tsx:138`                 |
+| `FormHandle.setValue(value, options)`        | raw → `rootNode.setValue`  | `Form.tsx:155`                 |
+| `FormHandle.node` / `findNode` / `findNodes` | 노드 자체 (raw 접근 가능)  | `Form.tsx:146`, `:152`, `:153` |
 
 정제의 내용은 스키마 옵션이 결정하며 `Form`은 그것을 알지 못한다 — 현재 `ArrayNode`의 `options.omitTrailing`이 유일한 적용 사례다. `Form`의 계약은 "어느 채널을 읽는가"까지이고, "무엇을 정제하는가"는 노드 쪽 계약이다.
 

--- a/packages/canard/schema-form/src/core/DETAIL.md
+++ b/packages/canard/schema-form/src/core/DETAIL.md
@@ -15,19 +15,19 @@
 
 ### 진입점 표면
 
-| 심볼 | 계약 |
-| ---- | ---- |
-| `nodeFromJsonSchema(props)` | JSON Schema → `SchemaNode` 트리. 이 fractal의 유일한 트리 생성 경로 |
-| `SchemaNode` 및 타입별 노드 | `value`·`normalizedValue`·`setValue`·`validate`·`subscribe`·`find`·`revision` 등 노드 공개 표면 |
-| `isSchemaNode` · `isBranchNode` · `isTerminalNode` · 타입별 가드 | 런타임 타입 판별 |
-| `NodeEventType` · `SetValueOption` · `ValidationMode` | 비트 플래그·열거값 |
+| 심볼                                                             | 계약                                                                                            |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `nodeFromJsonSchema(props)`                                      | JSON Schema → `SchemaNode` 트리. 이 fractal의 유일한 트리 생성 경로                             |
+| `SchemaNode` 및 타입별 노드                                      | `value`·`normalizedValue`·`setValue`·`validate`·`subscribe`·`find`·`revision` 등 노드 공개 표면 |
+| `isSchemaNode` · `isBranchNode` · `isTerminalNode` · 타입별 가드 | 런타임 타입 판별                                                                                |
+| `NodeEventType` · `SetValueOption` · `ValidationMode`            | 비트 플래그·열거값                                                                              |
 
 ### 값 채널 규약
 
-| 채널 | 읽는 곳 | 특성 |
-| ---- | ------- | ---- |
-| `value` (raw) | `UpdateValue` payload, 자식 상태 슬롯, `setValue` 왕복 | 정제되지 않음. 편집 중 상태를 보존 |
-| `normalizedValue` (정제) | 루트 검증, 루트 방출, `FormHandle.getValue`, 부모측 하이드레이션 | 스키마 출력 옵션 적용 |
+| 채널                     | 읽는 곳                                                          | 특성                               |
+| ------------------------ | ---------------------------------------------------------------- | ---------------------------------- |
+| `value` (raw)            | `UpdateValue` payload, 자식 상태 슬롯, `setValue` 왕복           | 정제되지 않음. 편집 중 상태를 보존 |
+| `normalizedValue` (정제) | 루트 검증, 루트 방출, `FormHandle.getValue`, 부모측 하이드레이션 | 스키마 출력 옵션 적용              |
 
 두 채널을 섞으면 편집 중인 화면이 정제 때문에 접히거나, 반대로 정제되지 않은 값이 폼 밖으로 나간다. 새 소비 지점을 추가할 때는 그 값이 밖으로 나가는지 안에 머무는지를 먼저 정하고 채널을 고른다.
 

--- a/packages/canard/schema-form/src/core/__tests__/BranchStrategy.composition.defaultValue.test.ts
+++ b/packages/canard/schema-form/src/core/__tests__/BranchStrategy.composition.defaultValue.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { delay } from '@winglet/common-utils';
+
+import { nodeFromJsonSchema } from '@/schema-form/core';
+
+import type { ObjectNode } from '../nodes/ObjectNode';
+import {
+  type CompositionCase,
+  createSchema,
+  expressDefault,
+} from './BranchStrategy.composition.fixtures';
+
+describe.each([
+  ['oneOf', 'oneOf'],
+  ['oneOf', 'anyOf'],
+  ['anyOf', 'oneOf'],
+  ['anyOf', 'anyOf'],
+] as const satisfies readonly CompositionCase[])(
+  'BranchStrategy nested composition %s → %s - constructor defaultValue',
+  (outerScope, innerScope) => {
+    it('preserves an explicit constructor defaultValue', async () => {
+      const node = nodeFromJsonSchema({
+        jsonSchema: createSchema(outerScope, innerScope),
+        defaultValue: {
+          enabled: true,
+          config: { mode: 'standard', cost: 8.5, days: 2 },
+        },
+        onChange: () => {},
+      }) as ObjectNode;
+
+      await delay();
+
+      expect(node.value).toEqual({
+        enabled: true,
+        config: { mode: 'standard', cost: 8.5, days: 2 },
+      });
+    });
+
+    it('fills nested defaults for a partial constructor defaultValue', async () => {
+      const node = nodeFromJsonSchema({
+        jsonSchema: createSchema(outerScope, innerScope),
+        defaultValue: {
+          enabled: true,
+          config: { mode: 'express' },
+        },
+        onChange: () => {},
+      }) as ObjectNode;
+
+      await delay();
+
+      expect(node.value).toEqual(expressDefault);
+    });
+  },
+);

--- a/packages/canard/schema-form/src/core/__tests__/BranchStrategy.composition.fixtures.ts
+++ b/packages/canard/schema-form/src/core/__tests__/BranchStrategy.composition.fixtures.ts
@@ -1,0 +1,74 @@
+import type { JsonSchema } from '@/schema-form/types';
+
+/** Composition keyword a branch level uses to declare its conditional subschemas. */
+export type CompositionScope = 'oneOf' | 'anyOf';
+
+/** One outer/inner composition pairing exercised by the nested-composition suites. */
+export type CompositionCase = [outer: CompositionScope, inner: CompositionScope];
+
+/**
+ * Builds the two-level conditional schema the nested-composition suites share.
+ *
+ * The outer level gates a `config` object on `enabled === true`; the inner level
+ * switches `config`'s extra properties on `config.mode`. Both levels take their
+ * composition keyword from the arguments so one schema shape covers all four
+ * `oneOf`/`anyOf` pairings.
+ *
+ * @param outerScope - composition keyword for the `enabled` gate
+ * @param innerScope - composition keyword for the `config.mode` branch
+ * @returns the assembled JSON Schema
+ */
+export const createSchema = (
+  outerScope: CompositionScope,
+  innerScope: CompositionScope,
+): JsonSchema => ({
+  type: 'object',
+  properties: {
+    enabled: { type: 'boolean', default: true },
+  },
+  [outerScope]: [
+    {
+      '&if': './enabled === true',
+      properties: {
+        config: {
+          type: 'object',
+          properties: {
+            mode: {
+              type: 'string',
+              enum: ['standard', 'express'],
+              default: 'standard',
+            },
+          },
+          [innerScope]: [
+            {
+              '&if': "./mode === 'standard'",
+              properties: {
+                cost: { type: 'number', default: 5.99 },
+                days: { type: 'number', default: 7 },
+              },
+            },
+            {
+              '&if': "./mode === 'express'",
+              properties: {
+                expressCost: { type: 'number', default: 15.99 },
+                hours: { type: 'number', default: 24 },
+              },
+            },
+          ],
+        },
+      },
+    },
+  ],
+});
+
+/** Fully defaulted value when the inner branch settles on `standard`. */
+export const standardDefault = {
+  enabled: true,
+  config: { mode: 'standard', cost: 5.99, days: 7 },
+};
+
+/** Fully defaulted value when the inner branch settles on `express`. */
+export const expressDefault = {
+  enabled: true,
+  config: { mode: 'express', expressCost: 15.99, hours: 24 },
+};

--- a/packages/canard/schema-form/src/core/__tests__/BranchStrategy.composition.fixtures.ts
+++ b/packages/canard/schema-form/src/core/__tests__/BranchStrategy.composition.fixtures.ts
@@ -4,7 +4,10 @@ import type { JsonSchema } from '@/schema-form/types';
 export type CompositionScope = 'oneOf' | 'anyOf';
 
 /** One outer/inner composition pairing exercised by the nested-composition suites. */
-export type CompositionCase = [outer: CompositionScope, inner: CompositionScope];
+export type CompositionCase = [
+  outer: CompositionScope,
+  inner: CompositionScope,
+];
 
 /**
  * Builds the two-level conditional schema the nested-composition suites share.

--- a/packages/canard/schema-form/src/core/__tests__/BranchStrategy.composition.merge.test.ts
+++ b/packages/canard/schema-form/src/core/__tests__/BranchStrategy.composition.merge.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { delay } from '@winglet/common-utils';
+
+import { SetValueOption, nodeFromJsonSchema } from '@/schema-form/core';
+
+import type { ObjectNode } from '../nodes/ObjectNode';
+import {
+  type CompositionCase,
+  createSchema,
+} from './BranchStrategy.composition.fixtures';
+
+describe.each([
+  ['oneOf', 'oneOf'],
+  ['oneOf', 'anyOf'],
+  ['anyOf', 'oneOf'],
+  ['anyOf', 'anyOf'],
+] as const satisfies readonly CompositionCase[])(
+  'BranchStrategy nested composition %s → %s - Merge',
+  (outerScope, innerScope) => {
+    it('preserves root fields during a nested Merge', async () => {
+      const node = nodeFromJsonSchema({
+        jsonSchema: createSchema(outerScope, innerScope),
+        onChange: () => {},
+      }) as ObjectNode;
+
+      await delay();
+      node.setValue(
+        { config: { mode: 'standard', cost: 10, days: 1 } },
+        SetValueOption.Merge,
+      );
+      await delay();
+
+      expect(node.value).toEqual({
+        enabled: true,
+        config: { mode: 'standard', cost: 10, days: 1 },
+      });
+    });
+
+    it('preserves nested values during a selector-only Merge', async () => {
+      const node = nodeFromJsonSchema({
+        jsonSchema: createSchema(outerScope, innerScope),
+        onChange: () => {},
+      }) as ObjectNode;
+
+      await delay();
+      node.setValue({
+        enabled: true,
+        config: { mode: 'standard', cost: 10, days: 1 },
+      });
+      await delay();
+
+      node.setValue({ enabled: true }, SetValueOption.Merge);
+      await delay();
+
+      expect(node.value).toEqual({
+        enabled: true,
+        config: { mode: 'standard', cost: 10, days: 1 },
+      });
+    });
+  },
+);

--- a/packages/canard/schema-form/src/core/__tests__/BranchStrategy.composition.setValue.test.ts
+++ b/packages/canard/schema-form/src/core/__tests__/BranchStrategy.composition.setValue.test.ts
@@ -2,78 +2,25 @@ import { describe, expect, it } from 'vitest';
 
 import { delay } from '@winglet/common-utils';
 
-import { SetValueOption, nodeFromJsonSchema } from '@/schema-form/core';
-import type { JsonSchema } from '@/schema-form/types';
+import { nodeFromJsonSchema } from '@/schema-form/core';
 
 import type { ObjectNode } from '../nodes/ObjectNode';
+import {
+  type CompositionCase,
+  createSchema,
+  expressDefault,
+  standardDefault,
+} from './BranchStrategy.composition.fixtures';
 
-type CompositionScope = 'oneOf' | 'anyOf';
-type CompositionCase = [outer: CompositionScope, inner: CompositionScope];
-
-const compositionCases: CompositionCase[] = [
+describe.each([
   ['oneOf', 'oneOf'],
   ['oneOf', 'anyOf'],
   ['anyOf', 'oneOf'],
   ['anyOf', 'anyOf'],
-];
-
-const createSchema = (
-  outerScope: CompositionScope,
-  innerScope: CompositionScope,
-): JsonSchema => ({
-  type: 'object',
-  properties: {
-    enabled: { type: 'boolean', default: true },
-  },
-  [outerScope]: [
-    {
-      '&if': './enabled === true',
-      properties: {
-        config: {
-          type: 'object',
-          properties: {
-            mode: {
-              type: 'string',
-              enum: ['standard', 'express'],
-              default: 'standard',
-            },
-          },
-          [innerScope]: [
-            {
-              '&if': "./mode === 'standard'",
-              properties: {
-                cost: { type: 'number', default: 5.99 },
-                days: { type: 'number', default: 7 },
-              },
-            },
-            {
-              '&if': "./mode === 'express'",
-              properties: {
-                expressCost: { type: 'number', default: 15.99 },
-                hours: { type: 'number', default: 24 },
-              },
-            },
-          ],
-        },
-      },
-    },
-  ],
-});
-
-const standardDefault = {
-  enabled: true,
-  config: { mode: 'standard', cost: 5.99, days: 7 },
-};
-
-const expressDefault = {
-  enabled: true,
-  config: { mode: 'express', expressCost: 15.99, hours: 24 },
-};
-
-describe('BranchStrategy nested composition - external value injection', () => {
-  it.each(compositionCases)(
-    '%s → %s preserves explicit values injected before initial settlement',
-    async (outerScope, innerScope) => {
+] as const satisfies readonly CompositionCase[])(
+  'BranchStrategy nested composition %s → %s - setValue injection',
+  (outerScope, innerScope) => {
+    it('preserves explicit values injected before initial settlement', async () => {
       const node = nodeFromJsonSchema({
         jsonSchema: createSchema(outerScope, innerScope),
         onChange: () => {},
@@ -89,12 +36,9 @@ describe('BranchStrategy nested composition - external value injection', () => {
         enabled: true,
         config: { mode: 'standard', cost: 12.5, days: 3 },
       });
-    },
-  );
+    });
 
-  it.each(compositionCases)(
-    '%s → %s fills nested defaults for a partial overwrite',
-    async (outerScope, innerScope) => {
+    it('fills nested defaults for a partial overwrite', async () => {
       const node = nodeFromJsonSchema({
         jsonSchema: createSchema(outerScope, innerScope),
         onChange: () => {},
@@ -105,12 +49,9 @@ describe('BranchStrategy nested composition - external value injection', () => {
       await delay();
 
       expect(node.value).toEqual(standardDefault);
-    },
-  );
+    });
 
-  it.each(compositionCases)(
-    '%s → %s applies only the latest synchronous pre-settlement injection',
-    async (outerScope, innerScope) => {
+    it('applies only the latest synchronous pre-settlement injection', async () => {
       const node = nodeFromJsonSchema({
         jsonSchema: createSchema(outerScope, innerScope),
         onChange: () => {},
@@ -130,12 +71,9 @@ describe('BranchStrategy nested composition - external value injection', () => {
         enabled: true,
         config: { mode: 'express', expressCost: 25, hours: 8 },
       });
-    },
-  );
+    });
 
-  it.each(compositionCases)(
-    '%s → %s restores the active object when an overwrite omits it',
-    async (outerScope, innerScope) => {
+    it('restores the active object when an overwrite omits it', async () => {
       const node = nodeFromJsonSchema({
         jsonSchema: createSchema(outerScope, innerScope),
         onChange: () => {},
@@ -146,12 +84,9 @@ describe('BranchStrategy nested composition - external value injection', () => {
       await delay();
 
       expect(node.value).toEqual(standardDefault);
-    },
-  );
+    });
 
-  it.each(compositionCases)(
-    '%s → %s fills defaults for a partial non-default inner branch',
-    async (outerScope, innerScope) => {
+    it('fills defaults for a partial non-default inner branch', async () => {
       const node = nodeFromJsonSchema({
         jsonSchema: createSchema(outerScope, innerScope),
         onChange: () => {},
@@ -162,12 +97,9 @@ describe('BranchStrategy nested composition - external value injection', () => {
       await delay();
 
       expect(node.value).toEqual(expressDefault);
-    },
-  );
+    });
 
-  it.each(compositionCases)(
-    '%s → %s restores defaults after external deactivation and reactivation',
-    async (outerScope, innerScope) => {
+    it('restores defaults after external deactivation and reactivation', async () => {
       const node = nodeFromJsonSchema({
         jsonSchema: createSchema(outerScope, innerScope),
         onChange: () => {},
@@ -182,51 +114,9 @@ describe('BranchStrategy nested composition - external value injection', () => {
       await delay();
 
       expect(node.value).toEqual(standardDefault);
-    },
-  );
+    });
 
-  it.each(compositionCases)(
-    '%s → %s preserves an explicit constructor defaultValue',
-    async (outerScope, innerScope) => {
-      const node = nodeFromJsonSchema({
-        jsonSchema: createSchema(outerScope, innerScope),
-        defaultValue: {
-          enabled: true,
-          config: { mode: 'standard', cost: 8.5, days: 2 },
-        },
-        onChange: () => {},
-      }) as ObjectNode;
-
-      await delay();
-
-      expect(node.value).toEqual({
-        enabled: true,
-        config: { mode: 'standard', cost: 8.5, days: 2 },
-      });
-    },
-  );
-
-  it.each(compositionCases)(
-    '%s → %s fills nested defaults for a partial constructor defaultValue',
-    async (outerScope, innerScope) => {
-      const node = nodeFromJsonSchema({
-        jsonSchema: createSchema(outerScope, innerScope),
-        defaultValue: {
-          enabled: true,
-          config: { mode: 'express' },
-        },
-        onChange: () => {},
-      }) as ObjectNode;
-
-      await delay();
-
-      expect(node.value).toEqual(expressDefault);
-    },
-  );
-
-  it.each(compositionCases)(
-    '%s → %s filters fields from an inactive inner branch',
-    async (outerScope, innerScope) => {
+    it('filters fields from an inactive inner branch', async () => {
       const node = nodeFromJsonSchema({
         jsonSchema: createSchema(outerScope, innerScope),
         onChange: () => {},
@@ -249,53 +139,6 @@ describe('BranchStrategy nested composition - external value injection', () => {
         enabled: true,
         config: { mode: 'express', expressCost: 20, hours: 12 },
       });
-    },
-  );
-
-  it.each(compositionCases)(
-    '%s → %s preserves root fields during a nested Merge',
-    async (outerScope, innerScope) => {
-      const node = nodeFromJsonSchema({
-        jsonSchema: createSchema(outerScope, innerScope),
-        onChange: () => {},
-      }) as ObjectNode;
-
-      await delay();
-      node.setValue(
-        { config: { mode: 'standard', cost: 10, days: 1 } },
-        SetValueOption.Merge,
-      );
-      await delay();
-
-      expect(node.value).toEqual({
-        enabled: true,
-        config: { mode: 'standard', cost: 10, days: 1 },
-      });
-    },
-  );
-
-  it.each(compositionCases)(
-    '%s → %s preserves nested values during a selector-only Merge',
-    async (outerScope, innerScope) => {
-      const node = nodeFromJsonSchema({
-        jsonSchema: createSchema(outerScope, innerScope),
-        onChange: () => {},
-      }) as ObjectNode;
-
-      await delay();
-      node.setValue({
-        enabled: true,
-        config: { mode: 'standard', cost: 10, days: 1 },
-      });
-      await delay();
-
-      node.setValue({ enabled: true }, SetValueOption.Merge);
-      await delay();
-
-      expect(node.value).toEqual({
-        enabled: true,
-        config: { mode: 'standard', cost: 10, days: 1 },
-      });
-    },
-  );
-});
+    });
+  },
+);

--- a/packages/canard/schema-form/src/core/nodes/AbstractNode/DETAIL.md
+++ b/packages/canard/schema-form/src/core/nodes/AbstractNode/DETAIL.md
@@ -21,22 +21,22 @@ public get normalizedValue(): Value | Nullish
 - **override 허용 범위**: 값 정제만. 시그니처와 `Value | Nullish` 반환 타입을 유지해야 하며, `value`가 `null`/`undefined`일 때 그 nullish 상태를 다른 값으로 바꾸지 않는다.
 - **소비 지점** — 이 네 곳이 정제값을 읽는다. 새 소비 지점을 추가할 때는 raw가 아니라 이 getter를 읽는지 확인한다.
 
-| 소비 지점 | 위치 | 읽는 이유 |
-| --------- | ---- | --------- |
-| 루트 validation 값 | `AbstractNode.ts:710` (`__enhancedValue__`) | 검증 대상은 실제로 제출될 값이어야 한다 |
-| 루트 방출 | `AbstractNode.ts:1148` (`__handleChange__` → `onChange(getSafeEmptyValue(...))`) | 폼 밖으로 나가는 값 |
-| `FormHandle.getValue` · `submit` | `components/Form/Form.tsx` | 명령형 API가 돌려주는 값 |
-| 부모측 하이드레이션 스냅샷 | `ArrayNode/strategies/BranchStrategy` (`__sourceMap__`의 `output` 슬롯) | 부모가 자식으로부터 받아 두는 기여값 |
+| 소비 지점                        | 위치                                                                             | 읽는 이유                               |
+| -------------------------------- | -------------------------------------------------------------------------------- | --------------------------------------- |
+| 루트 validation 값               | `AbstractNode.ts:710` (`__enhancedValue__`)                                      | 검증 대상은 실제로 제출될 값이어야 한다 |
+| 루트 방출                        | `AbstractNode.ts:1148` (`__handleChange__` → `onChange(getSafeEmptyValue(...))`) | 폼 밖으로 나가는 값                     |
+| `FormHandle.getValue` · `submit` | `components/Form/Form.tsx`                                                       | 명령형 API가 돌려주는 값                |
+| 부모측 하이드레이션 스냅샷       | `ArrayNode/strategies/BranchStrategy` (`__sourceMap__`의 `output` 슬롯)          | 부모가 자식으로부터 받아 두는 기여값    |
 
 ### 서브클래스 의무
 
-| 멤버 | 필수 | 계약 |
-| ---- | ---- | ---- |
-| `type` | 예 | 노드의 스키마 타입. `integer`는 `number`로 정규화되어 노출된다 |
-| `value` getter/setter | 예 | raw 값 |
-| `applyValue(input, option)` | 예 | 옵션 비트에 따른 값 적용과 이벤트 발행 |
-| `normalizedValue` | 아니오 | 정제가 필요할 때만 override |
-| `__equals__(left, right)` | 아니오 | 기본은 참조 동등(`===`). 깊은 비교가 필요할 때만 override |
+| 멤버                        | 필수   | 계약                                                           |
+| --------------------------- | ------ | -------------------------------------------------------------- |
+| `type`                      | 예     | 노드의 스키마 타입. `integer`는 `number`로 정규화되어 노출된다 |
+| `value` getter/setter       | 예     | raw 값                                                         |
+| `applyValue(input, option)` | 예     | 옵션 비트에 따른 값 적용과 이벤트 발행                         |
+| `normalizedValue`           | 아니오 | 정제가 필요할 때만 override                                    |
+| `__equals__(left, right)`   | 아니오 | 기본은 참조 동등(`===`). 깊은 비교가 필요할 때만 override      |
 
 ## Acceptance Criteria
 

--- a/packages/canard/schema-form/src/core/nodes/ArrayNode/strategies/DETAIL.md
+++ b/packages/canard/schema-form/src/core/nodes/ArrayNode/strategies/DETAIL.md
@@ -16,19 +16,19 @@
 
 `type.ts`가 정의하는 `ArrayNodeStrategy` 멤버:
 
-| 멤버 | 시그니처 | 계약 |
-| ---- | -------- | ---- |
-| `value` | `get value(): ArrayValue \| Nullish` | raw 상태. 후행 빈 항목이 살아 있다 |
-| `normalizedValue` | `get normalizedValue(): ArrayValue \| Nullish` | 자식의 `normalizedValue` 합성. 자식이 없는 전략은 `value` 자신 |
-| `length` | `get length(): number` | 현재 항목 수 |
-| `minItems` · `maxItems` | `get (): number` | JSON Schema 제약 |
-| `children` | `get children(): ChildNode[] \| null` | 자식 없는 전략은 `null` |
-| `applyValue` | `(value, option: UnionSetValueOption) => void` | 옵션 비트로 방출 이벤트를 결정 |
-| `push` | `(data?, unlimited?) => Promise<number>` | `unlimited !== true`면 `maxItems` 가드 |
-| `update` · `remove` | `(index, ...) => Promise<ArrayValue[number] \| undefined>` | 범위 밖이면 `undefined` |
-| `pop` | `() => Promise<ArrayValue[number] \| undefined>` | 비어 있으면 `undefined` |
-| `clear` | `() => Promise<void>` | 전부 제거 |
-| `initialize?` | `() => void` | 선택적. 자식 pub-sub 연결 |
+| 멤버                    | 시그니처                                                   | 계약                                                           |
+| ----------------------- | ---------------------------------------------------------- | -------------------------------------------------------------- |
+| `value`                 | `get value(): ArrayValue \| Nullish`                       | raw 상태. 후행 빈 항목이 살아 있다                             |
+| `normalizedValue`       | `get normalizedValue(): ArrayValue \| Nullish`             | 자식의 `normalizedValue` 합성. 자식이 없는 전략은 `value` 자신 |
+| `length`                | `get length(): number`                                     | 현재 항목 수                                                   |
+| `minItems` · `maxItems` | `get (): number`                                           | JSON Schema 제약                                               |
+| `children`              | `get children(): ChildNode[] \| null`                      | 자식 없는 전략은 `null`                                        |
+| `applyValue`            | `(value, option: UnionSetValueOption) => void`             | 옵션 비트로 방출 이벤트를 결정                                 |
+| `push`                  | `(data?, unlimited?) => Promise<number>`                   | `unlimited !== true`면 `maxItems` 가드                         |
+| `update` · `remove`     | `(index, ...) => Promise<ArrayValue[number] \| undefined>` | 범위 밖이면 `undefined`                                        |
+| `pop`                   | `() => Promise<ArrayValue[number] \| undefined>`           | 비어 있으면 `undefined`                                        |
+| `clear`                 | `() => Promise<void>`                                      | 전부 제거                                                      |
+| `initialize?`           | `() => void`                                               | 선택적. 자식 pub-sub 연결                                      |
 
 `index.ts`가 노출하는 공개 표면은 `BranchStrategy`, `TerminalStrategy`, 그리고 타입 `ArrayNodeStrategy` 셋뿐이다.
 


### PR DESCRIPTION
## Architecture

- 이 PR은 `documents/` 사이트만 건드립니다 — 패키지 `src`는 diff에 없습니다. #326(omitTrailing 기능)에 **스택된 후속 PR**이며, base가 `schema-form/omitTrailing`인 이유는 데모가 그 브랜치의 API(`options.omitTrailing`, `node.normalizedValue`)에 의존하기 때문입니다. #326이 머지되면 base는 자동으로 master로 재지정됩니다.
- 신규 데모는 기존 예제 11개의 구조를 그대로 따릅니다: `demos/examples/*Demo.tsx`(default export, 모듈 최상위 스키마 상수, `DemoWrapper`) + `docs/.../examples/*.mdx`(en) + `i18n/ko/.../examples/*.mdx`(ko) + 양쪽 `index.mdx` 목록 등록. `DemoWrapper`는 10개 데모의 공유 표면이라 수정하지 않았습니다.
- **선행 조건 기록**: `documents`는 `@canard/schema-form`을 workspace 심볼릭 링크 → `dist`로 소비합니다(src alias 없음). 검증 전 `yarn workspace @canard/schema-form build`로 dist를 갱신했습니다 — 갱신 전 dist에는 `omitTrailing`이 없어 데모가 아무것도 증명하지 못하고 `node.normalizedValue`가 타입 에러가 됩니다.

## Code

- `documents/src/components/demos/examples/ArrayOutputFiltersDemo.tsx` — 형태가 같고(`minItems: 3`, 문자열 항목) `options`만 다른 배열 3개를 A/B 대조로 렌더링. 폼 아래 표가 노드별로 `node.value`(raw) vs `node.normalizedValue`(방출)와 렌더된 행 수를 나란히 보여줍니다.
  - `/tags` = `{ omitTrailing: true }` → 첫 렌더 시 키 자체가 사라짐(`[]` → omitEmpty)
  - `/notes` = 옵션 없음(대조군) → `[null, null, null]`
  - `/aliases` = `{ omitTrailing: true, omitEmpty: false }` → `[]` (필터 순서 경계)
- 추적은 **배열 노드마다** `useSchemaNodeTracker`를 겁니다. 빈 행을 Add해도 정제된 루트 값은 그대로라 루트 하나만 추적하면 raw 패널이 낡습니다 — 이 데모의 존재 이유가 그 차이입니다.
- `JSON.stringify(undefined)`는 문자열이 아니라 `undefined`를 돌려주고 React가 아무것도 렌더하지 않으므로 `?? 'undefined'` 폴백을 둡니다. `/tags`가 사라지는 것이 핵심 관찰 대상입니다.
- 문서 페이지(en/ko)는 `minItems`와 validation의 상호작용을 `:::caution`으로 명시합니다 — validation은 정제된 값을 읽으므로 한 행만 채워진 배열은 길이 1로 검증됩니다.
- validator 플러그인은 등록하지 않습니다. 기존 11개 중 ajv8을 쓰는 것은 `prefixItems`가 Draft 2020-12를 요구하는 `TupleArraysDemo` 하나뿐이고, 이 기능은 검증에 의존하지 않습니다.

## Test

- 신규 테스트 없음(문서/데모 전용). 문서가 주장하는 값은 전부 #326의 기존 테스트가 이미 고정하고 있습니다:
  - `/tags` 초기 방출값 = 키 없음 → `ArrayNode.omitTrailing.test.ts` "should chain into omitEmpty when every item is undefined", `array.omit-trailing.render.test.tsx` "renders every empty input while the emitted value omits them"
  - `/aliases` = `[]` → "should keep the emptied array when omitEmpty is disabled"
  - `/notes` 미트림 → "should not trim when omitTrailing is not enabled (opt-in)"
  - `:::caution`의 minItems 주장 → "validates the trimmed value at a root-level array (minItems sees the trim)"
- 검증(모두 종료 코드로 판정): `yarn workspace @canard/schema-form build` exit 0 · `yarn workspace @albatrion/documents typecheck` exit 0(`tsc --listFiles`로 신규 데모 포함 확인) · `yarn workspace @albatrion/documents build` exit 0, en/ko 양쪽에 `array-output-filters` 페이지 생성 확인, 빌드 로그 warning 0
- **미검증**: 브라우저 실행 중 상호작용(입력 타이핑 → 표 갱신)은 확인하지 않았습니다. 컴파일·타입·정적 빌드까지가 이 PR의 증거 범위입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
